### PR TITLE
runtests.py is also not required in release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 tests/** export-ignore
+enjarify/runtests.py export-ignore


### PR DESCRIPTION
Since tests/ is now excluded from release tarballs, it makes no sense to keep runtests.py in it.
