### PR TITLE
add debug.py for debugger to avoid relative import error in main.py

### DIFF
--- a/debug.py
+++ b/debug.py
@@ -1,0 +1,3 @@
+import enjarify.main
+
+enjarify.main.main()


### PR DESCRIPTION
I think the following problem i'v met is very common for other users, no matter which python debugger used.

For example, I am using PyCharm to debug enjarify, 
i set `main.py` as startup script, see following picture:
<img width="868" alt="pycharm debugger settings" src="https://cloud.githubusercontent.com/assets/5234060/14581254/e25571ca-0422-11e6-8967-7975a2ddc73c.png">

but `main.py` went error at:

```
from . import parsedex
```

Error message:

```
/usr/local/Cellar/pypy3/2.4.0/libexec/bin/pypy "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py" --multiproc --qt-support --client 127.0.0.1 --port 50129 --file /Users/q/Documents/enjarify/enjarify/main.py /tmp/a.apk -o /tmp/a.jar -f
pydev debugger: process 2139 is connecting

Connected to pydev debugger (build 143.1919)
Traceback (most recent call last):
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py", line 2411, in <module>
    globals = debugger.run(setup['file'], None, None, is_module)
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py", line 1802, in run
    launch(file, globals, locals)  # execute the script
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/Users/q/Documents/enjarify/enjarify/main.py", line 17, in <module>
    from . import parsedex
ValueError: Attempted relative import in non-package

Process finished with exit code 1
```

The reason is i invoke `main.py` as file mode, not as `package mode`. To invoke `main.py` as `package` mode, i must specify following option to replace `main.py` in command line

```
-m enjarify.main
```

The easiest way to solve this problem is change `main.py`

```
from enjarify import parsedex
```

But I do not want to change source file, 

so i tried following debug config:
<img width="865" alt="pycharm debugger settings specify package mode" src="https://cloud.githubusercontent.com/assets/5234060/14581260/4e4c11e0-0423-11e6-8285-2b3000d8ff19.png">

but this way still does not works, just exit silently. The command line have both `--module` and `--file` option which seems can not be controlled by settings and maybe cause problem.

```
/usr/local/Cellar/pypy3/2.4.0/libexec/bin/pypy "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py" --multiproc --module --qt-support --client 127.0.0.1 --port 50274 --file enjarify.main /tmp/a.apk -o /tmp/a.jar -f
pydev debugger: process 2205 is connecting

Connected to pydev debugger (build 143.1919)

Process finished with exit code 0
```

The `main.py`:main is not executed because the `__name__` is not `"__main__"` at this time.

<img width="882" alt="__name__is_not_main" src="https://cloud.githubusercontent.com/assets/5234060/14581288/1392f87e-0424-11e6-8635-f667ba499bc5.png">

I have no way to make debugger works without modifying main.py.

So, what about add a launcher script for debugger? no more modification later.
`debug.py`

```
import enjarify.main

enjarify.main.main()
```

<img width="863" alt="debug py" src="https://cloud.githubusercontent.com/assets/5234060/14581559/e672b422-042a-11e6-84f9-dbf47a36249c.png">

So debugger normally calls `main.py`:main for me.

Any better idea is welcome.
