### PR TITLE
add ACC_SUPER flag to non-interface class so super.someMethod can be correctly handled

### DIFF
--- a/enjarify/parsedex.py
+++ b/enjarify/parsedex.py
@@ -17,6 +17,7 @@ import array
 from .byteio import Reader
 from .dalvik import parseBytecode
 from .util import signExtend
+from . import flags
 
 NO_INDEX = 0xFFFFFFFF
 
@@ -212,6 +213,10 @@ class DexClass:
         self.data_off = words[6]
         self.data = None # parse data lazily in parseData()
         self.constant_values_off = words[7]
+
+        #dex ignored ACC_SUPER flag, so restore it here
+        if not self.access & flags.ACC_INTERFACE:
+            self.access |= flags.ACC_SUPER
 
     def parseData(self):
         if self.data is None:


### PR DESCRIPTION
There are an notable problem which been fixed in <a href="https://sourceforge.net/p/dex2jar/wiki/DalvikVSJvm/">dex2jar</a> previously:
Many converted class lost `ACC_SUPER` flag which cause `super.someMethod()` go to non-existent abstract method (throw error).

When android's dx utility convert java class to dex, it discards `ACC_SUPER` flag of class, so `enjarify` should restore it when convert back to jar.

The full modification of `dex2jar` is here
https://github.com/pxb1988/dex2jar/blob/master/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java#L91

According to jvm's spec, interface should not have `ACC_SUPER` flag.
