### PR TITLE
Fix APK upper case extension bug

### DIFF
--- a/enjarify/main.py
+++ b/enjarify/main.py
@@ -62,7 +62,7 @@ def main():
     args = parser.parse_args()
 
     dexs = []
-    if args.inputfile.endswith('.apk'):
+    if args.inputfile.lower().endswith('.apk'):
         with zipfile.ZipFile(args.inputfile, 'r') as z:
             for name in z.namelist():
                 if name.startswith('classes') and name.endswith('.dex'):


### PR DESCRIPTION
Enjarify fails when the extension of apk is in uppercase.

Ex: `abc.APK`

This fix allows enjarify to handle uppercase extension as well.
