### PR TITLE
val None error handling

### DIFF
--- a/enjarify/jvm/constantpool.py
+++ b/enjarify/jvm/constantpool.py
@@ -98,6 +98,11 @@ class ConstantPoolBase:
         if item is None:
             return
         tag, val = item
+
+        if val is None:
+            # val might be None in some cases and triggers error in len(val)
+            return
+
         stream.u8(tag)
 
         if tag == CONSTANT_Utf8:


### PR DESCRIPTION
`val` value might be None in some cases and triggers error in `len(val)`